### PR TITLE
Revert slang build.yaml config

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -14,7 +14,7 @@ targets:
           base_locale: en
           fallback_strategy: base_locale
           input_file_pattern: .i18n.yaml
+          flat_map: false
           timestamp: false
           key_case: camel
           param_case: camel
-          translation_overrides: true

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -844,21 +844,21 @@ packages:
       name: slang
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.5.0"
+    version: "3.6.0"
   slang_build_runner:
     dependency: "direct dev"
     description:
       name: slang_build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.5.0"
+    version: "3.6.0"
   slang_flutter:
     dependency: "direct main"
     description:
       name: slang_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.5.0"
+    version: "3.6.0"
   source_gen:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -71,8 +71,8 @@ dependencies:
   scroll_to_index: ^3.0.1
   separated_row: ^2.0.0
   shimmer: ^2.0.0
-  slang_flutter: ^3.4.0
-  slang: ^3.4.0
+  slang_flutter: ^3.6.0
+  slang: ^3.6.0
   tinycolor2: ^3.0.0
   url_launcher: ^6.0.3
   video_player: ^2.2.5
@@ -91,7 +91,7 @@ dev_dependencies:
   hive_generator: ^2.0.0
   json_serializable: ^6.0.1
   riverpod_generator: ^1.0.4
-  slang_build_runner: ^3.4.0
+  slang_build_runner: ^3.6.0
 
 flutter_icons:
   android: true


### PR DESCRIPTION
There was a bug in slang which is fixed in `v3.5.0`. `translation_overrides` is not necessary to use custom plural resolvers.