### PR TITLE
Add the required changes for F-Droid

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -94,3 +94,15 @@ flutter {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
+
+
+ext.abiCodes = ["armeabi-v7a": 1, "arm64-v8a": 2, "x86_64": 4]
+import com.android.build.OutputFile
+android.applicationVariants.all { variant ->
+  variant.outputs.each { output ->
+    def abiVersionCode = project.ext.abiCodes.get(output.getFilter(OutputFile.ABI))
+    if (abiVersionCode != null) {
+      output.versionCodeOverride = variant.versionCode * 10 + abiVersionCode
+    }
+  }
+}

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,3 +3,4 @@ distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionSha256Sum=97a52d145762adc241bad7fd18289bf7f6801e08ece6badf80402fe2b9f250b1


### PR DESCRIPTION
[X]https://github.com/nullxception/boorusphere/commit/dbaf77192a635821d936e7dbd1545e04ffddc04e : Changes the versioning code scheme from the default `abi * 1000 + vercode` to `vercode * 10 + abi`, as requested by the F-Droid dev linsui at https://gitlab.com/fdroid/fdroiddata/-/merge_requests/13506#note_1608664649
[X]https://github.com/nullxception/boorusphere/commit/1fc042585c95201ddd673818b6558a2474e8f952 : Add distributionSha256Sum field to gradle wrapper properties to ensure the integrity of the downloaded gradle package, prevents attacks where a malicious or corrupt version would be offered for download on the gradle distribution website. This would fix one of the many annoying warnings about this being missing, presumably all the others are located in dependencies, and while it would be preferable to have them do it as well, I'm not likely to go through all of them one by one to ask them to do the same.
[ ] Reproducible build support : As asked by Izzy at https://gitlab.com/fdroid/fdroiddata/-/merge_requests/13506#note_1501746673 and recommended by F-Droid in general. I am not sure how to fix the specific issue he mentioned but I'm putting it up here so we can figure it out. Will be linking this in the F-Droid Merge Request so they can come help too if possible, as I'm neither an Android or Flutter dev, so this is all a bit beyond me at the moment.

Finally, this PR should close https://github.com/nullxception/boorusphere/issues/152 (can't figure out how to make it close it if merged from here atm though)